### PR TITLE
TypeError: 'NoneType' object is not iterable

### DIFF
--- a/zanataclient/zanatalib/project.py
+++ b/zanataclient/zanatalib/project.py
@@ -42,7 +42,8 @@ class Project(object):
             if not a == 'links': 
                 setattr(self, str(a), b)
             else:
-                setattr(self, str(a), [Link(item) for item in b])
+                if b is not None:
+                    setattr(self, str(a), [Link(item) for item in b])
 
     def set_iteration(self, iterations):
         self.__iterations = iterations


### PR DESCRIPTION
If item b is None, we should not try to iterate over it.

zanata pull --srcdir .. causes the following error:

Traceback (most recent call last):
  File "/usr/bin/zanata", line 25, in <module>
    zanata.run()
  File "/usr/lib/python2.7/site-packages/zanataclient/zanata.py", line 945, in run
    program_name=os.path.split(sys.argv[0])[1],
  File "/usr/lib/python2.7/site-packages/zanataclient/command.py", line 339, in handle_program
    command(command_options, args)
  File "/usr/lib/python2.7/site-packages/zanataclient/zanata.py", line 820, in pull
    command.run(command_options, args, project_type)
  File "/usr/lib/python2.7/site-packages/zanataclient/pullcmd.py", line 74, in run
    zanatacmd.verify_project(project_id, version_id)
  File "/usr/lib/python2.7/site-packages/zanataclient/zanatacmd.py", line 103, in verify_project
    self.zanata_resource.projects.get(project_id)
  File "/usr/lib/python2.7/site-packages/zanataclient/zanatalib/projectservice.py", line 85, in get
    project = Project(server_return)
  File "/usr/lib/python2.7/site-packages/zanataclient/zanatalib/project.py", line 47, in **init**
    setattr(self, str(a), [Link(item) for item in b])
TypeError: 'NoneType' object is not iterable
