### PR TITLE
Found hard coded gettext string  instead of project_type

### DIFF
--- a/zanataclient/pushcmd.py
+++ b/zanataclient/pushcmd.py
@@ -540,7 +540,7 @@ class PoPush(Push):
         importpo = self.get_importpo(self.command_options)
         if importpo:
             log.info("Importing translation")
-            import_param = self.get_importparam("gettext", self.command_options, self.project_config, tmlfolder)
+            import_param = self.get_importparam(project_type, self.command_options, self.project_config, tmlfolder)
         else:
             log.info("Importing source documents only")
 


### PR DESCRIPTION
I've been attempting for some time to do a push of translations from a podir (multiple files in a directory) did not succeed 
After some debugging i found that this hardcodded 'gettext' which I assume to be a bug? 

All I know is tat after this fix, I do get to transfer my translation files