### PR TITLE
Fixing po pull for podir project_type order of selection

### DIFF
--- a/zanataclient/pullcmd.py
+++ b/zanataclient/pullcmd.py
@@ -81,13 +81,13 @@ class GenericPull(Push):
         else:
             locale_map = None
 
-        if self.project_type:
-            command_type = self.project_type
-            dir_option = True
-        elif self.command_options.has_key('project_type'):
+        if self.command_options.has_key('project_type'):
             command_type = self.command_options['project_type'][0]['value']
         elif self.project_config['project_type']:
             command_type = self.project_config['project_type']
+        elif self.project_type:
+            command_type = self.project_type
+            dir_option = True
         else:
             log.error("The project type is unknown")
             sys.exit(1)

--- a/zanataclient/zanatacmd.py
+++ b/zanataclient/zanatacmd.py
@@ -481,7 +481,7 @@ class ZanataCommand:
                         os.makedirs(subdirectory)
                     pofile = os.path.join(subdirectory, save_name + '.po')
                 else:
-                    pofile = os.path.join(output, save_name + '.po')
+                    pofile = os.path.join(outpath, save_name + '.po')
 
                 self.log.info("Retrieving %s translation from server:" % item)
 


### PR DESCRIPTION
When pulling translations it appears self.project_type takes precedent
   In reality command line should take precedentover config and config
should take precedent over the self.project_type
This would force the files to not be saved with the language as a
filename.

On the zanatacmd.py I seem to have found a bug where output was used
instead of outpath which which would end up forcing all language files
to be saved under the same directory