### PR TITLE
ZNTA-946: zanata push StringIO fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
-* Web Mar 02 2016 Sundeep Anand <suanand@redhat.com>
+* Web Apr 13 2016 Sundeep Anand <suanand@redhat.com> - 1.5.0
+- ZNTA-946 - zanata push StringIO fix
+- ZNTA-303 - podir projects handling
 - ZNTA-936 - redirection 301, 302 handling
 - ZNTA-934 - java-client compatible zanata.xml
 - ZNTA-927 - Project Status and Versions

--- a/zanataclient/zanatalib/projectutils.py
+++ b/zanataclient/zanatalib/projectutils.py
@@ -198,6 +198,8 @@ class FileMappingRule(object):
         subdirectory = map_path[:map_path.rfind('/')]
         if subdirectory and not os.path.isdir(subdirectory):
             os.makedirs(subdirectory)
+        if '//' in map_path:
+            map_path = map_path.replace('//', '/')
         return map_path
 
     def _apply_standard_mapping_rules(self):

--- a/zanataclient/zanatalib/rest/client.py
+++ b/zanataclient/zanatalib/rest/client.py
@@ -30,7 +30,10 @@ except ImportError:
 import os
 import sys
 import warnings
-from io import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 warnings.simplefilter("ignore", DeprecationWarning)
 import httplib2
 


### PR DESCRIPTION
[ZNTA-303](https://zanata.atlassian.net/browse/ZNTA-303) Python client does not support podirs correctly
[ZNTA-946](https://zanata.atlassian.net/browse/ZNTA-946) Cannot push with zanata Python client 1.4.2

@definite Please have a look.