### PR TITLE
download only those which have translations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Wed Oct 05 2016 Sundeep Anand <suanand@redhat.com>
+* Thu Oct 06 2016 Sundeep Anand <suanand@redhat.com>
 - Bug 1368381 - download only those which have translations
 - ZNTA-106 - zanata-python-client installs a test module
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
-* Fri May 06 2016 Sundeep Anand <suanand@redhat.com>
+* Wed Oct 05 2016 Sundeep Anand <suanand@redhat.com>
+- Bug 1368381 - download only those which have translations
 - ZNTA-106 - zanata-python-client installs a test module
 
 * Thu Apr 14 2016 Sundeep Anand <suanand@redhat.com> - 1.5.0

--- a/zanataclient/publicanutil.py
+++ b/zanataclient/publicanutil.py
@@ -492,7 +492,10 @@ class PublicanUtility:
                         if poentry.flags == [u'']:
                             poentry.flags = None
 
-        # finally save resulting po to outpath as lang/myfile.po
-        po.save()
-        # pylint: disable=E1103
-        self.log.info("Writing po file to %s" % (path))
+            # finally save resulting po to outpath as lang/myfile.po
+            po.save()
+            # pylint: disable=E1103
+            self.log.success("Writing po file to %s" % (path))
+
+        else:
+            self.log.warn("No translations found in %s for document %s" % (locale, doc_name))

--- a/zanataclient/pullcmd.py
+++ b/zanataclient/pullcmd.py
@@ -36,7 +36,7 @@ class GenericPull(PushPull):
         super(GenericPull, self).__init__(*args, **kargs)
 
     def run(self):
-        skeletons = True
+        skeletons = False
         filelist = []
         output_folder = None
 
@@ -68,14 +68,13 @@ class GenericPull(PushPull):
                 log.warn("dstdir option is changed to transdir option for generic pull command")
                 output_folder = self.context_data.get('dstdir')
 
-        if 'noskeletons' in self.context_data:
-            skeletons = False
+        if 'skeletons' in self.context_data:
+            skeletons = True
 
-        mindocpercent = self.context_data['mindocpercent'] if self.context_data.get('mindocpercent') else 1
         outpath = self.create_outpath(output_folder)
         filedict = self.zanatacmd.get_project_translation_stats(
-            self.project_id, self.version_id, mindocpercent, lang_list, locale_map
-        )
+            self.project_id, self.version_id, self.context_data['mindocpercent'], lang_list, locale_map
+        ) if self.context_data.get('mindocpercent') else dict((file, lang_list) for file in filelist)
 
         self.zanatacmd.pull_command(locale_map, self.project_id, self.version_id,
                                     filedict, outpath, command_type, skeletons, self.file_mapping_rules)

--- a/zanataclient/pullcmd.py
+++ b/zanataclient/pullcmd.py
@@ -71,10 +71,11 @@ class GenericPull(PushPull):
         if 'noskeletons' in self.context_data:
             skeletons = False
 
+        mindocpercent = self.context_data['mindocpercent'] if self.context_data.get('mindocpercent') else 1
         outpath = self.create_outpath(output_folder)
         filedict = self.zanatacmd.get_project_translation_stats(
-            self.project_id, self.version_id, self.context_data['mindocpercent'], lang_list, locale_map
-        ) if self.context_data.get('mindocpercent') else dict((file, lang_list) for file in filelist)
+            self.project_id, self.version_id, mindocpercent, lang_list, locale_map
+        )
 
         self.zanatacmd.pull_command(locale_map, self.project_id, self.version_id,
                                     filedict, outpath, command_type, skeletons, self.file_mapping_rules)

--- a/zanataclient/zanata.py
+++ b/zanataclient/zanata.py
@@ -252,10 +252,10 @@ option_sets = {
             long=['--sourcecommentsastarget'],
         ),
     ],
-    'noskeletons': [
+    'skeletons': [
         dict(
             type='command',
-            long=['--noskeletons'],
+            long=['--create-skeletons'],
         ),
     ],
     'pushtransonly': [
@@ -501,7 +501,7 @@ def po_pull(command_options, args):
         --disable-ssl-cert  : disable ssl certificate validation
         --dstdir            : output folder (same as --transdir option)
         --lang              : language list
-        --noskeleton        : omit po files when translations not found
+        --create-skeletons  : download po files even if translations not found
         --project-id        : id of the project (defaults to zanata.xml value)
         --project-version   : id of the version (defaults to zanata.xml value)
         --transdir          : output folder for po files
@@ -551,7 +551,7 @@ def publican_pull(command_options, args):
         --disable-ssl-cert  : disable ssl certificate validation
         --dstdir            : output folder (same as --transdir option)
         --lang              : language list
-        --noskeleton        : omit po files when translations not found
+        --create-skeletons  : download po files even if translations not found
         --project-id        : id of the project (defaults to zanata.xml value)
         --project-version   : id of the version (defaults to zanata.xml value)
         --transdir          : translations will be written to this folder (one sub-folder per locale)
@@ -635,7 +635,7 @@ def pull(command_options, args, project_type=None):
         --lang              : language list (defaults to zanata.xml locales)
         --min-doc-percent   : Only pull translation documents that have at least this percentage of messages translated.
                                 Accepts an integer from 0 to 100.
-        --noskeletons       : omit po files when translations not found
+        --create-skeletons  : download po files even if translations not found
         --project-id        : id of the project (defaults to zanata.xml value)
         --project-type      : project type (gettext or podir)
         --project-version   : id of the version (defaults to zanata.xml value)

--- a/zanataclient/zanatacmd.py
+++ b/zanataclient/zanatacmd.py
@@ -129,7 +129,7 @@ class ZanataCommand:
         try:
             result = self.zanata_resource.documents.update_template(project_id, iteration_id, request_name, body, copytrans)
             if result:
-                self.log.info("Successfully updated template %s on the server" % filename)
+                self.log.success("Successfully updated template %s on the server" % filename)
         except ZanataException as e:
             self.log.error(str(e))
 
@@ -138,7 +138,7 @@ class ZanataCommand:
             result = self.zanata_resource.documents.commit_translation(project_id, iteration_id, request_name, lang, body, merge)
             if result:
                 self.log.warn(result)
-            self.log.info("Successfully pushed translation %s to the Zanata server" % pofile)
+            self.log.success("Successfully pushed translation %s to the Zanata server" % pofile)
         except ZanataException as e:
             self.log.error(str(e))
 
@@ -151,7 +151,7 @@ class ZanataCommand:
             sys.exit(1)
 
         if filelist:
-            self.log.info("This will overwrite/delete any existing documents on the server.")
+            self.log.warn("This will overwrite/delete any existing documents on the server.")
             if not force:
                 while True:
                     option = input("Are you sure (y/n)?")
@@ -280,7 +280,7 @@ class ZanataCommand:
             p = Project(item)
             result = self.zanata_resource.projects.create(p)
             if result:
-                self.log.info("Successfully created project: %s" % project_id)
+                self.log.success("Successfully created project: %s" % project_id)
                 return True
         except ZanataException as e:
             self.log.error(str(e))
@@ -295,7 +295,7 @@ class ZanataCommand:
             iteration = Iteration(item)
             result = self.zanata_resource.projects.iterations.create(project_id, iteration)
             if result:
-                self.log.info("Successfully created version: %s" % version_id)
+                self.log.success("Successfully created version: %s" % version_id)
                 return True
         except ZanataException as e:
             self.log.error(str(e))
@@ -414,7 +414,7 @@ class ZanataCommand:
             try:
                 result = self.update_template(project_id, iteration_id, filename, body, copytrans)
                 if result:
-                    self.log.info("Successfully pushed %s to the server" % filepath)
+                    self.log.success("Successfully pushed %s to the server" % filepath)
             except UnAuthorizedException as e:
                 self.log.error(str(e))
                 break
@@ -494,13 +494,15 @@ class ZanataCommand:
                 self.log.info("Retrieving %s translation from server: " % local_lang)
 
                 try:
-                    result = self.zanata_resource.documents.retrieve_translation(remote_lang, project_id, iteration_id, request_name, skeletons)
+                    result = self.zanata_resource.documents.retrieve_translation(
+                        remote_lang, project_id, iteration_id, request_name, skeletons
+                    )
                     publicanutil.save_to_pofile(file_mapped_path, result, pot, skeletons, local_lang, name)
                 except UnAuthorizedException as e:
                     self.log.error(str(e))
                     break
                 except UnAvaliableResourceException as e:
-                    self.log.info("There is no %s translation for %s" % (local_lang, name))
+                    self.log.warn("There is no %s translation for %s" % (local_lang, name))
                 except BadRequestBodyException as e:
                     self.log.error(str(e))
                     continue
@@ -564,13 +566,10 @@ class ZanataCommand:
                         disqualify_locales.append(locale)
                 disqualify_locales = [alias for alias, locale in locale_map.items()
                                       for lang in disqualify_locales if lang == locale]
-                if disqualify_locales and min_doc_percent != 1:
+                if disqualify_locales:
                     self.log.info('Translation file for document %s for locales [%s] are skipped '
                                   'because they are less than %s%% translated (--min-doc-percent setting)' %
                                   (doc, ', '.join(map(str, disqualify_locales)), min_doc_percent))
-                else:
-                    self.log.info('No translations found for document %s for locales [%s]' %
-                                  (doc, ', '.join(map(str, disqualify_locales))))
                 qualify_lang_set = set(lang_list) - set(disqualify_locales)
                 doc_locales_dict.update({doc: list(qualify_lang_set)})
         finally:

--- a/zanataclient/zanatacmd.py
+++ b/zanataclient/zanatacmd.py
@@ -564,10 +564,13 @@ class ZanataCommand:
                         disqualify_locales.append(locale)
                 disqualify_locales = [alias for alias, locale in locale_map.items()
                                       for lang in disqualify_locales if lang == locale]
-                if disqualify_locales:
+                if disqualify_locales and min_doc_percent != 1:
                     self.log.info('Translation file for document %s for locales [%s] are skipped '
                                   'because they are less than %s%% translated (--min-doc-percent setting)' %
                                   (doc, ', '.join(map(str, disqualify_locales)), min_doc_percent))
+                else:
+                    self.log.info('No translations found for document %s for locales [%s]' %
+                                  (doc, ', '.join(map(str, disqualify_locales))))
                 qualify_lang_set = set(lang_list) - set(disqualify_locales)
                 doc_locales_dict.update({doc: list(qualify_lang_set)})
         finally:

--- a/zanataclient/zanatalib/docservice.py
+++ b/zanataclient/zanatalib/docservice.py
@@ -101,6 +101,9 @@ class DocumentService(Service):
             'retrieve_translation', projectid, iterationid, file_id, lang,
             headers=self.http_headers, extension=ext
         )
+        # for no-skeletons server returns 404
+        if not skeletons and res.status == 404:
+            return False
         return self.messages(res, content)
 
     def commit_translation(self, projectid, iterationid, fileid, localeid, resources, merge):

--- a/zanataclient/zanatalib/logger.py
+++ b/zanataclient/zanatalib/logger.py
@@ -40,24 +40,36 @@ class Logger:
         self.enable_infoprefix = True
         self.enable_warnprefix = True
         self.enable_errprefix = True
+        self.enable_successprefix = True
+        self.success_prefix = '[SUCCESS] '
         self.warn_prefix = '[WARN] '
         self.error_prefix = '[ERROR] '
         self.info_prefix = '[INFO] '
 
+    def success(self, message):
+        if self.enable_successprefix:
+            print(TextColour.OKGREEN + self.success_prefix
+                  + message + TextColour.ENDC)
+        else:
+            print(message)
+
     def info(self, message):
         if self.enable_infoprefix:
-            print(self.info_prefix + message)
+            print(TextColour.OKBLUE + self.info_prefix
+                  + message + TextColour.ENDC)
         else:
             print(message)
 
     def warn(self, message):
         if self.enable_warnprefix:
-            print(self.warn_prefix + message)
+            print(TextColour.WARNING + self.warn_prefix
+                  + message + TextColour.ENDC)
         else:
             print(message)
 
     def error(self, message):
         if self.enable_errprefix:
-            print(self.error_prefix + message)
+            print(TextColour.FAIL + self.error_prefix
+                  + message + TextColour.ENDC)
         else:
             print(message)

--- a/zanataclient/zanatalib/rest/client.py
+++ b/zanataclient/zanatalib/rest/client.py
@@ -141,10 +141,10 @@ class RestHandle(object):
                 url = self._get_url()
         elif rest_resp.previous and rest_resp.previous.status == 302 and 'location' in rest_resp.previous:
             url = rest_resp.previous['location']
-            self._http_https_msg(url)
+            # self._http_https_msg(url)
         elif rest_resp.status == 302 and 'location' in rest_resp:
             url = rest_resp['location']
-            self._http_https_msg(url)
+            # self._http_https_msg(url)
         return self._call_request(url, self.method, **args_dict)
 
     def get_response_content(self):


### PR DESCRIPTION
[Bug 1368381](https://bugzilla.redhat.com/show_bug.cgi?id=1368381) - `zanata pull` downloads **all** .po files, even those which have no translations at all.

@definite Please have a look.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-python-client/48)
<!-- Reviewable:end -->
