### PR TITLE
ZNTA-1382: "--push-trans-only" should be deprecated

### DIFF
--- a/zanataclient/cmdbase.py
+++ b/zanataclient/cmdbase.py
@@ -397,7 +397,7 @@ class PushPull(CommandsBase):
         return trans_folder
 
     def create_outpath(self, output_folder):
-        if 'transdir'in self.context_data:
+        if 'transdir' in self.context_data:
             output = self.context_data.get('transdir')
         elif output_folder:
             output = output_folder

--- a/zanataclient/publicanutil.py
+++ b/zanataclient/publicanutil.py
@@ -492,7 +492,10 @@ class PublicanUtility:
                         if poentry.flags == [u'']:
                             poentry.flags = None
 
-            # finally save resulting po to outpath as lang/myfile.po
+            # finally save resulting po to outpath
+            subdirectory = path[:path.rfind('/')]
+            if subdirectory and not os.path.isdir(subdirectory):
+                os.makedirs(subdirectory)
             po.save()
             # pylint: disable=E1103
             self.log.success("Writing po file to %s" % (path))

--- a/zanataclient/zanata.py
+++ b/zanataclient/zanata.py
@@ -608,7 +608,6 @@ def push(command_options, args):
         --project-id        : id of the project (defaults to zanata.xml value)
         --project-type      : project type (gettext or podir)
         --project-version   : id of the version (defaults to zanata.xml value)
-        --push-trans-only   : push translations only
         --push-type         : source: push source document only,
                                 target: push translations only, same as push-trans-only
                                 both: push source and translations together, same as push-trans
@@ -618,6 +617,7 @@ def push(command_options, args):
         --username          : user name (defaults to zanata.ini value)
         -f                  : force to remove content on server side
         --push-trans        : deprecated: use '--push-type both' instead
+        --push-trans-only   : deprecated: use '--push-type target' instead
     """
     pass
 

--- a/zanataclient/zanatalib/projectutils.py
+++ b/zanataclient/zanatalib/projectutils.py
@@ -196,9 +196,6 @@ class FileMappingRule(object):
             if os.path.isabs(map_path):
                 map_path = map_path[1:]
             map_path = os.path.join(self.translation_folder, map_path)
-        subdirectory = map_path[:map_path.rfind('/')]
-        if subdirectory and not os.path.isdir(subdirectory):
-            os.makedirs(subdirectory)
         if '//' in map_path:
             map_path = map_path.replace('//', '/')
         return map_path


### PR DESCRIPTION
 - [ZNTA 1382](https://zanata.atlassian.net/browse/ZNTA-1382) Should "--push-trans-only" be deprecated in the python client?
- Following `file-mapping-rules` in `zanata pull` sub-directories should only be created in case `po` file/s is/are to be saved.

@definite Please have a look.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-python-client/49)
<!-- Reviewable:end -->
