### PR TITLE
README doesn't mention the stats option.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ https://github.com/zanata/zanata-server/blob/master/zanata.xml
 
 You can also override the URL of the server with the command line option
 ``--url``.  Use ``--username`` for user name and ``--apikey`` for api key of
-user. 
+user.
 
 Command List
 ============
@@ -209,3 +209,6 @@ will load all the info from the configuration file::
 
     $ zanata po pull
 
+If you want to retrieve the statistics for a project version, you can use the command below::
+
+    $ zanata stats --project-id={project_id} --project-version={iteration_id}


### PR DESCRIPTION
I was looking for this option, since I use the stats API as part of my build. I cloned the repo and downloaded to add stats, and then found that it had already exposed it! What a treat!

I thought the rest of the world should know.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-python-client/50)
<!-- Reviewable:end -->
