### PR TITLE
Fix incorrect "fuzzy" flags in po files when multiple langs are pulled

### DIFF
--- a/zanataclient/publicanutil.py
+++ b/zanataclient/publicanutil.py
@@ -413,7 +413,7 @@ class PublicanUtility:
                             poentry.occurrences = None
 
                         if entry.get('flags'):
-                            poentry.flags = entry.get('flags')
+                            poentry.flags = [flag for flag in entry.get('flags')]
 
                         if entry.get('context') is not None:
                             poentry.msgctxt = entry.get('context')


### PR DESCRIPTION
When saving po files, the poentry "flags" list is initialized with a
reference to the pot textflow "flags" list. The poentry "flags" list
is then extended to add the "fuzzy" flag for any translation which is
marked as needs review. This modifies the original pot textflow "flags"
list too.

As a result, when the next language is processed everything that was
marked fuzzy in all previous languages saved is also marked fuzzy in
this next language. IOW, when you download multiple lanuages, the po
files generated get an every increasing number of entries marked as
fuzzy despite being correctly translated. This totally trashes the
generated .po files, as fuzzy entries are discarded by gettext when
creating .gmo files.

The trivial fix is to just deep clone the flags list instead of sharing
the reference.

Any project which currently uses the zanata python client needs to
consider their current .po files as largely garbage, because they
will be full of inappropriate "fuzzy" annotations.

Signed-off-by: Daniel P. Berrangé <berrange@redhat.com>